### PR TITLE
Use relative path for recent.js request

### DIFF
--- a/app/views/rails_performance/javascripts/app.js
+++ b/app/views/rails_performance/javascripts/app.js
@@ -181,7 +181,7 @@ if(recent) {
       return;
     }
 
-    fetch(`/rails/performance/recent.js?from_timei=${from_timei}`, {
+    fetch(`recent.js?from_timei=${from_timei}`, {
       headers: {
         "X-CSRF-Token": document.querySelector("[name='csrf-token']").content,
       },


### PR DESCRIPTION
Auto Update on recent requests was using an absolute path which does not
account for /rails/performance being mounted to another url. Changed the
path to use a relative path instead.