### PR TITLE
Add ability to skip rake task (for example  asset precompile) for per…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ RailsPerformance.setup do |config|
 
   # config home button link
   config.home_link = '/'
+
+  config.skipable_rake_tasks = ['webpacker:compile']
 end if defined?(RailsPerformance)
 ```
 

--- a/lib/rails_performance.rb
+++ b/lib/rails_performance.rb
@@ -73,6 +73,10 @@ module RailsPerformance
   mattr_accessor :home_link
   @@home_link = '/'
 
+  # skip performance tracking for these rake tasks
+  mattr_accessor :skipable_rake_tasks
+  @@skipable_rake_tasks = []
+
   def RailsPerformance.setup
     yield(self)
   end

--- a/lib/rails_performance/gems/rake_ext.rb
+++ b/lib/rails_performance/gems/rake_ext.rb
@@ -13,13 +13,15 @@ module RailsPerformance
               status = 'error'
               raise(ex)
             ensure
-              RailsPerformance::Models::RakeRecord.new(
-                task: RailsPerformance::Gems::RakeExt.find_task_name(*args),
-                datetime: now.strftime(RailsPerformance::FORMAT),
-                datetimei: now.to_i,
-                duration: (Time.now - now) * 1000,
-                status: status,
-              ).save
+              if !RailsPerformance.skipable_rake_tasks.include?(self.name)
+                RailsPerformance::Models::RakeRecord.new(
+                  task: RailsPerformance::Gems::RakeExt.find_task_name(*args),
+                  datetime: now.strftime(RailsPerformance::FORMAT),
+                  datetimei: now.to_i,
+                  duration: (Time.now - now) * 1000,
+                  status: status,
+                ).save
+              end
             end
           end
 


### PR DESCRIPTION
When running asset precompile for rails, rails performance gem tries to connect to redis. This change gives the option to exclude certain rake tasks from performance tracking.

Config example:
```ruby
    config.skipable_rake_tasks = ['assets:precompile']
```